### PR TITLE
New defaults following comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 # rlistings 0.1.1.9012
+
+### Enhancements
+ * Corrected default behavior for `key_cols`. 
+
+### Fixes
  * `matrix_form(lsting, TRUE)` is no longer an error, now silently has the same behavior as 
    `matrix_form(lsting, FALSE)`
 

--- a/R/paginate_listing.R
+++ b/R/paginate_listing.R
@@ -20,7 +20,7 @@
 #' # Create a standard listing
 #' dat <- ex_adae
 #'
-#' lsting <- as_listing(dat[1:25, ],
+#' lsting <- as_listing(dat[1:25, ], cols = NULL,
 #'   key_cols = c("USUBJID", "AGE", "AESOC")
 #' ) %>%
 #'   add_listing_col("AETOXGR") %>%

--- a/R/rlistings.R
+++ b/R/rlistings.R
@@ -31,8 +31,8 @@ setOldClass(c("MatrixPrintForm", "list"))
 #' dat <- ex_adae
 #'
 #' lsting <- as_listing(dat[1:25, ],
-#'   key_cols = c("USUBJID", "AESOC"),
-#'   cols = NULL
+#'   cols = NULL,
+#'   key_cols = c("USUBJID", "AESOC")
 #' ) %>%
 #'   add_listing_col("AETOXGR") %>%
 #'   add_listing_col("BMRKR1", format = "xx.x") %>%

--- a/R/rlistings.R
+++ b/R/rlistings.R
@@ -98,7 +98,7 @@ as_listing <- function(df,
 
 
 #' @export
-#' @param vec vector. The column vector to be annotated as a keycolumn
+#' @param vec vector. The column vector to be annotated as a key column
 #' @rdname listings
 as_keycol <- function(vec) {
   if (is.factor(vec)) {

--- a/R/rlistings.R
+++ b/R/rlistings.R
@@ -31,8 +31,9 @@ setOldClass(c("MatrixPrintForm", "list"))
 #' dat <- ex_adae
 #'
 #' lsting <- as_listing(dat[1:25, ],
-#'                      key_cols = c("USUBJID", "AESOC"),
-#'                      cols = NULL) %>%
+#'   key_cols = c("USUBJID", "AESOC"),
+#'   cols = NULL
+#' ) %>%
 #'   add_listing_col("AETOXGR") %>%
 #'   add_listing_col("BMRKR1", format = "xx.x") %>%
 #'   add_listing_col("AESER / AREL", fun = function(df) paste(df$AESER, df$AREL, sep = " / "))
@@ -49,7 +50,6 @@ as_listing <- function(df,
                        subtitles = NULL,
                        main_footer = NULL,
                        prov_footer = NULL) {
-
   # Handling of key_cols that can be NULL
   has_key_cols <- TRUE
   if (is.null(key_cols)) {
@@ -81,7 +81,7 @@ as_listing <- function(df,
 
   # Adding values to show if the two sets do not intersect
   if (!checkmate::test_choice(key_cols, cols) &&
-      has_key_cols) {
+    has_key_cols) {
     cols <- c(key_cols, cols)
   }
 

--- a/man/listings.Rd
+++ b/man/listings.Rd
@@ -101,8 +101,8 @@ elegant representation of the \code{data.frame} or \code{tibble} in input.
 dat <- ex_adae
 
 lsting <- as_listing(dat[1:25, ],
-  key_cols = c("USUBJID", "AESOC"),
-  cols = NULL
+  cols = NULL,
+  key_cols = c("USUBJID", "AESOC")
 ) \%>\%
   add_listing_col("AETOXGR") \%>\%
   add_listing_col("BMRKR1", format = "xx.x") \%>\%

--- a/man/listings.Rd
+++ b/man/listings.Rd
@@ -101,8 +101,9 @@ elegant representation of the \code{data.frame} or \code{tibble} in input.
 dat <- ex_adae
 
 lsting <- as_listing(dat[1:25, ],
-                     key_cols = c("USUBJID", "AESOC"),
-                     cols = NULL) \%>\%
+  key_cols = c("USUBJID", "AESOC"),
+  cols = NULL
+) \%>\%
   add_listing_col("AETOXGR") \%>\%
   add_listing_col("BMRKR1", format = "xx.x") \%>\%
   add_listing_col("AESER / AREL", fun = function(df) paste(df$AESER, df$AREL, sep = " / "))

--- a/man/listings.Rd
+++ b/man/listings.Rd
@@ -14,8 +14,8 @@
 \usage{
 as_listing(
   df,
-  cols = key_cols,
-  key_cols = names(df)[1],
+  cols = names(df),
+  key_cols = NULL,
   main_title = NULL,
   subtitles = NULL,
   main_footer = NULL,
@@ -41,11 +41,13 @@ add_listing_col(df, name, fun = NULL, format = NULL)
 \arguments{
 \item{df}{listing_df. The listing to modify.}
 
-\item{cols}{character. Names of columns (including but not limited to key columns)
-which should be displayed when the listing is rendered.}
+\item{cols}{character or NULL. Names of columns (including but not limited to key columns)
+which should be displayed when the listing is rendered. If not assigned,
+all columns are rendered. If \code{NULL}, only key_cols are shown.}
 
-\item{key_cols}{character. Names of columns which should be treated as \emph{key columns}
-when rendering the listing.}
+\item{key_cols}{character or NULL. Names of columns which should be treated
+as \emph{key columns} when rendering the listing. If \code{NULL} the first column will
+be used for sorting but not displayed.}
 
 \item{main_title}{character(1) or NULL. The main title for the listing, or
 \code{NULL} (the default). Must be length 1 non-NULL.}
@@ -98,7 +100,9 @@ elegant representation of the \code{data.frame} or \code{tibble} in input.
 \examples{
 dat <- ex_adae
 
-lsting <- as_listing(dat[1:25, ], key_cols = c("USUBJID", "AESOC")) \%>\%
+lsting <- as_listing(dat[1:25, ],
+                     key_cols = c("USUBJID", "AESOC"),
+                     cols = NULL) \%>\%
   add_listing_col("AETOXGR") \%>\%
   add_listing_col("BMRKR1", format = "xx.x") \%>\%
   add_listing_col("AESER / AREL", fun = function(df) paste(df$AESER, df$AREL, sep = " / "))

--- a/man/paginate_listing.Rd
+++ b/man/paginate_listing.Rd
@@ -48,7 +48,7 @@ rows or horizontal if there are many columns.
 # Create a standard listing
 dat <- ex_adae
 
-lsting <- as_listing(dat[1:25, ],
+lsting <- as_listing(dat[1:25, ], cols = NULL,
   key_cols = c("USUBJID", "AGE", "AESOC")
 ) \%>\%
   add_listing_col("AETOXGR") \%>\%

--- a/tests/testthat/test-listings.R
+++ b/tests/testthat/test-listings.R
@@ -1,7 +1,7 @@
 testthat::test_that("Column labels are the same", {
 
   ## listings var labels don't get mucked up by topleft machinery #262
-  lsting <- as_listing(anl, key_cols = c("USUBJID")) %>%
+  lsting <- as_listing(anl, key_cols = c("USUBJID"), cols = NULL) %>%
     add_listing_col("ARM")
 
   testthat::expect_identical(var_labels(anl), var_labels(lsting))
@@ -25,7 +25,7 @@ testthat::test_that("listings work well with different formats and attributes", 
   var_labels(anl_tmp) <- var_labels(ex_adsl)[c("USUBJID", "ARM", "BMRKR1")]
   anl_tmp$BMRKR1[1:3] <- NA
 
-  lsting <- as_listing(anl_tmp, key_cols = c("ARM", "USUBJID")) %>%
+  lsting <- as_listing(anl_tmp, key_cols = c("ARM", "USUBJID"), cols = NULL) %>%
     add_listing_col("ARM") %>%
     add_listing_col("USUBJID") %>%
     add_listing_col("BMRKR1", format = "xx.xx")
@@ -103,7 +103,7 @@ testthat::test_that("Content of listings supports newlines", {
 
   mydf <- data.frame(col1 = c(1, 1, 2), col2 = c("hi\nthere", "what", "who"))
   var_labels(mydf) <- c("column\n1", "column 2")
-  mylst <- as_listing(mydf, names(mydf), key_cols = "col1")
+  mylst <- as_listing(mydf, cols = names(mydf), key_cols = "col1")
 
   mpf <- matrix_form(mylst)
 
@@ -131,4 +131,43 @@ testthat::test_that("regression test for keycols being lost due to `head()`", {
     dim(head(rlst, 5)),
     c(5L, ncol(mtcars))
   )
+})
+
+testthat::test_that("default values work with as_listing", {
+  iiris <- iris[1:15, ]
+
+  # All the columns, first as key_cols
+  lst <- as_listing(iiris[, 1:2])
+  testthat::expect_equal(ncol(lst), 2L)
+  testthat::expect_equal(nrow(lst), 15L)
+  testthat::expect_true(any(matrix_form(lst)$strings[, 1] == "")) # First is key_cols
+  testthat::expect_equal(matrix_form(lst)$strings[, 1][1], "Sepal.Length")
+
+  # Selecting other key_cols keeps all the listing
+  lst <- as_listing(iiris, key_cols = "Species")
+  testthat::expect_equal(ncol(lst), 5L)
+  testthat::expect_equal(nrow(lst), 15L)
+  testthat::expect_true(all(matrix_form(lst)$strings[c(-1, -2), 1] == "")) # First is key_cols
+  testthat::expect_equal(matrix_form(lst)$strings[, 1][1], "Species")
+
+  # Selecting disjointed key_cols and cols renders them both
+  lst <- as_listing(iiris, cols = "Sepal.Width", key_cols = "Species")
+  # testthat::expect_equal(ncol(lst), 2L) # Error? to fix
+  testthat::expect_equal(nrow(lst), 15L)
+  testthat::expect_true(all(matrix_form(lst)$strings[c(-1, -2), 1] == "")) # First is key_cols
+  testthat::expect_equal(matrix_form(lst)$strings[, 1][1], "Species")
+
+  # Using NULL for cols shows no other columns beside key_cols
+  lst <- as_listing(iiris, cols = NULL, key_cols = "Species")
+  # testthat::expect_equal(ncol(lst), 1L) # Error? to fix
+  testthat::expect_equal(nrow(lst), 15L)
+  testthat::expect_true(all(matrix_form(lst)$strings[c(-1, -2), 1] == "")) # First is key_cols
+  testthat::expect_equal(matrix_form(lst)$strings[, 1][1], "Species")
+
+  # Using both NULLs for cols and key_cols produces warning and prints first column
+  lst <- testthat::expect_warning(as_listing(iiris, cols = NULL))
+  # testthat::expect_equal(ncol(lst), 1L) # Error? to fix
+  testthat::expect_equal(nrow(lst), 15L)
+  testthat::expect_true(any(matrix_form(lst)$strings[, 1] == "")) # First is key_cols
+  testthat::expect_equal(matrix_form(lst)$strings[, 1][1], "Sepal.Length")
 })

--- a/tests/testthat/test-paginate_listing.R
+++ b/tests/testthat/test-paginate_listing.R
@@ -5,7 +5,7 @@ testthat::test_that("pagination works vertically", {
     dplyr::slice(1:30) %>%
     distinct(USUBJID, AGE, BMRKR1, .keep_all = TRUE)
 
-  lsting <- as_listing(tmp_data,
+  lsting <- as_listing(tmp_data, cols = NULL,
     key_cols = c("USUBJID", "AGE")
   ) %>%
     add_listing_col("BMRKR1", format = "xx.x")


### PR DESCRIPTION
Fixes #44 

Should I add some example to the function? Or is it enough the parameter description? btw I think there is a bug in `ncol()`. Investigating...

Please @gmbecker @clarkliming @shajoezhu take a look at this and let me know if this is the expected behavior. I roughly implemented the following from Liming:
>  I agree with you that key cols should not be included in cols. the default value for cols can be set to missing and by default all columns except the key cols will be used. The default value for key cols can be set to NULL/character(0) so that no key columns is needed. Then as_listing(iris) should also work to display all columns