### PR TITLE
adding rmarkdown to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,8 @@ Suggests:
     dplyr,
     knitr,
     lifecycle,
-    testthat
+    testthat,
+    rmarkdown
 VignetteBuilder: 
     knitr
 Config/Needs/website: insightsengineering/nesttemplate


### PR DESCRIPTION
I got this error:
```
* creating vignettes ... ERROR
--- re-building ‘rlistings.Rmd’ using rmarkdown
Error: processing vignette 'rlistings.Rmd' failed with diagnostics:
The 'rmarkdown' package should be installed and declared as a dependency of the 'rlistings' package (e.g., in the 'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'rmarkdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
--- failed re-building ‘rlistings.Rmd’
```
Maybe, because of R build parameters. 
No blocker.