### PR TITLE
add rmarkdown to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Suggests:
     dplyr,
     knitr,
     lifecycle,
+    rmarkdown,
     testthat
 VignetteBuilder: 
     knitr


### PR DESCRIPTION
Fix R CMD BUILD error (only when vignette build is on)

```
* creating vignettes ... ERROR
--- re-building ‘rlistings.Rmd’ using rmarkdown
Error: processing vignette 'rlistings.Rmd' failed with diagnostics:
The 'rmarkdown' package should be installed and declared as a dependency of the 'rlistings' package (e.g., in the 'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'rmarkdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
--- failed re-building ‘rlistings.Rmd’

SUMMARY: processing the following file failed:
  ‘rlistings.Rmd’

Error: Vignette re-building failed.
Execution halted
```