### PR TITLE
Add format configuration and `unique_rows` arguments to `as_listing`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 ## rlistings 0.2.2.9001
+ * Added new arguments `default_formatting` and `col_formatting` to `as_listing` to specify column format configurations.
+ * Added new argument `unique_rows` to `as_listing` to remove duplicate rows from listing.
 
 ## rlistings 0.2.2
  * Moved `export_as_txt` to `formatters`. Added to reexports. 

--- a/R/rlistings.R
+++ b/R/rlistings.R
@@ -25,7 +25,7 @@ setOldClass(c("MatrixPrintForm", "list"))
 #'   numeric classes) and a value of type `fmt_config` with the format configuration that should be implemented for
 #'   columns of that class. If named element "all" is included in the list, this configuration will be used for all
 #'   data classes not specified. Objects of type `fmt_config` can take 3 arguments: `format`, `na_str`, and `align`.
-#' @param col_formatting list. A named list of custom column formatting configuarations to apply to specific columns
+#' @param col_formatting list. A named list of custom column formatting configurations to apply to specific columns
 #'   when rendering the listing. Each name-value pair consists of a name corresponding to a column name and a value of
 #'   type `fmt_config` with the formatting configuration that should be implemented for that column. Objects of type
 #'   `fmt_config` can take 3 arguments: `format`, `na_str`, and `align`. Defaults to `NULL`.
@@ -369,7 +369,7 @@ add_listing_dispcol <- function(df, new) {
 #'   returns the vector for a new column, which is added to \code{df} as
 #'   \code{name}, or NULL if marking an existing column as
 #'   a listing column.
-#' @inheritParams formatters::format_value
+#' @inheritParams formatters::fmt_config
 #'
 #' @return `df`, with `name` created (if necessary) and marked for
 #'   display during rendering.

--- a/R/rlistings.R
+++ b/R/rlistings.R
@@ -103,6 +103,22 @@ setOldClass(c("MatrixPrintForm", "list"))
 #'
 #' cat(toString(mat))
 #'
+#' # This example demonstrates a listing with format configurations specified via the default_formatting
+#' # and col_formatting arguments
+#' dat <- ex_adae
+#' dat$AENDY[3:6] <- NA
+#' lsting <- as_listing(dat[1:25, ],
+#'   key_cols = c("USUBJID", "AESOC"),
+#'   disp_cols = c("STUDYID", "SEX", "ASEQ", "RANDDT", "ASTDY", "AENDY"),
+#'   default_formatting = list(all = fmt_config(align = "left"),
+#'                             numeric = fmt_config(format = "xx.xx", na_str = "<No data>", align = "right"))
+#' ) %>%
+#'   add_listing_col("BMRKR1", format = "xx.x", align = "center")
+#'
+#' mat <- matrix_form(lsting)
+#'
+#' cat(toString(mat))
+#'
 #' @export
 as_listing <- function(df,
                        key_cols = names(df)[1],
@@ -358,7 +374,7 @@ add_listing_dispcol <- function(df, new) {
 #'   display during rendering.
 #'
 #' @export
-add_listing_col <- function(df, name, fun = NULL, format = NULL, na_str = "-", align = "center") {
+add_listing_col <- function(df, name, fun = NULL, format = NULL, na_str = "NA", align = "center") {
   if (!is.null(fun)) {
     vec <- fun(df)
   } else if (name %in% names(df)) {

--- a/R/rlistings.R
+++ b/R/rlistings.R
@@ -376,7 +376,7 @@ add_listing_col <- function(df, name, fun = NULL, format = NULL, na_str = "-", a
   }
 
   obj_na_str(vec) <- na_str
-  vec@align <- align
+  obj_align(vec) <- align
 
   ## this works for both new and existing columns
   df[[name]] <- vec

--- a/R/rlistings.R
+++ b/R/rlistings.R
@@ -98,6 +98,7 @@ as_listing <- function(df,
                        key_cols = names(df)[1],
                        disp_cols = NULL,
                        non_disp_cols = NULL,
+                       unique_rows = FALSE,
                        default_formatting = list(all = fmt_config()),
                        col_formatting = NULL,
                        main_title = NULL,
@@ -154,6 +155,8 @@ as_listing <- function(df,
     obj_align(df[[col]]) <- col_fmt@align
     df[[col]]
   })
+
+  if (unique_rows) df <- df[!duplicated(df[, cols]), ]
 
   class(df) <- c("listing_df", class(df))
   ## these all work even when the value is NULL

--- a/R/rlistings.R
+++ b/R/rlistings.R
@@ -19,6 +19,16 @@ setOldClass(c("MatrixPrintForm", "list"))
 #' @param non_disp_cols character or NULL. Names of non-key columns to be excluded as display
 #'   columns. All other non-key columns are then treated as display columns. Invalid if
 #'   `disp_cols` is non-NULL.
+#' @param unique_rows logical(1). Should only unique rows be included in the listing. Defaults to `FALSE`.
+#' @param default_formatting list. A named list of default column format configurations to apply when rendering the
+#'   listing. Each name-value pair consists of a name corresponding to a data type (or "numeric" for all numeric
+#'   classes) and a value of type `fmt_config` with the format configuration that should be implemented for columns
+#'   of that type. If named element "all" is included in the list, this configuration will be used for all data types
+#'   not specified. Objects of type `fmt_config` can take 3 arguments: `format`, `na_str`, and `align`.
+#' @param col_formatting list. A named list of custom column formatting configuarations to apply to specific columns
+#'   when rendering the listing. Each name-value pair consists of a name corresponding to a column name and a value of
+#'   type `fmt_config` with the formatting configuration that should be implemented for that column. Objects of type
+#'   `fmt_config` can take 3 arguments: `format`, `na_str`, and `align`. Defaults to `NULL`.
 #' @param main_title character(1) or NULL. The main title for the listing, or
 #'   `NULL` (the default). Must be length 1 non-NULL.
 #' @param subtitles character or NULL. A vector of subtitle(s) for the
@@ -138,8 +148,8 @@ as_listing <- function(df,
   ## key cols must be leftmost cols
   cols <- c(key_cols, setdiff(cols, key_cols))
 
+  # set col format configs
   df[cols] <- lapply(cols, function(col) {
-    names(default_formatting) <- tolower(names(default_formatting))
     col_type <- if (is.numeric(df[[col]])) "numeric" else tolower(tail(class(df[[col]]), 1))
     col_fmt <- if (col %in% names(col_formatting)) {
       col_formatting[[col]]
@@ -152,7 +162,7 @@ as_listing <- function(df,
     }
     obj_format(df[[col]]) <- col_fmt@format
     obj_na_str(df[[col]]) <- obj_na_str(col_fmt)
-    obj_align(df[[col]]) <- col_fmt@align
+    obj_align(df[[col]]) <- obj_align(col_fmt)
     df[[col]]
   })
 

--- a/man/listings.Rd
+++ b/man/listings.Rd
@@ -69,7 +69,7 @@ numeric classes) and a value of type \code{fmt_config} with the format configura
 columns of that class. If named element "all" is included in the list, this configuration will be used for all
 data classes not specified. Objects of type \code{fmt_config} can take 3 arguments: \code{format}, \code{na_str}, and \code{align}.}
 
-\item{col_formatting}{list. A named list of custom column formatting configuarations to apply to specific columns
+\item{col_formatting}{list. A named list of custom column formatting configurations to apply to specific columns
 when rendering the listing. Each name-value pair consists of a name corresponding to a column name and a value of
 type \code{fmt_config} with the formatting configuration that should be implemented for that column. Objects of type
 \code{fmt_config} can take 3 arguments: \code{format}, \code{na_str}, and \code{align}. Defaults to \code{NULL}.}
@@ -101,10 +101,11 @@ returns the vector for a new column, which is added to \code{df} as
 \code{name}, or NULL if marking an existing column as
 a listing column.}
 
-\item{format}{character(1) or function. The format label (string) or \code{formatter} function to apply to \code{x}.}
+\item{format}{character(1) or function. A format label (string) or \code{formatter} function.}
 
-\item{na_str}{character(1). String that should be displayed when the value of \code{x} is missing.
-Defaults to \code{"NA"}.}
+\item{na_str}{character(1). String that should be displayed in place of missing values.}
+
+\item{align}{character(1). Alignment values should be rendered with.}
 }
 \value{
 A \code{listing_df} object, sorted by the key columns.

--- a/man/listings.Rd
+++ b/man/listings.Rd
@@ -42,7 +42,7 @@ add_listing_col(
   name,
   fun = NULL,
   format = NULL,
-  na_str = "-",
+  na_str = "NA",
   align = "center"
 )
 }
@@ -175,6 +175,22 @@ cat(toString(mat))
 # and specifying the cols with disp_cols.
 dat <- ex_adae
 lsting <- as_listing(dat[1:25, ], disp_cols = c("USUBJID", "AESOC", "RACE", "AETOXGR", "BMRKR1"))
+
+mat <- matrix_form(lsting)
+
+cat(toString(mat))
+
+# This example demonstrates a listing with format configurations specified via the default_formatting
+# and col_formatting arguments
+dat <- ex_adae
+dat$AENDY[3:6] <- NA
+lsting <- as_listing(dat[1:25, ],
+  key_cols = c("USUBJID", "AESOC"),
+  disp_cols = c("STUDYID", "SEX", "ASEQ", "RANDDT", "ASTDY", "AENDY"),
+  default_formatting = list(all = fmt_config(align = "left"),
+                            numeric = fmt_config(format = "xx.xx", na_str = "<No data>", align = "right"))
+) \%>\%
+  add_listing_col("BMRKR1", format = "xx.x", align = "center")
 
 mat <- matrix_form(lsting)
 

--- a/man/listings.Rd
+++ b/man/listings.Rd
@@ -64,9 +64,9 @@ columns. All other non-key columns are then treated as display columns. Invalid 
 \item{unique_rows}{logical(1). Should only unique rows be included in the listing. Defaults to \code{FALSE}.}
 
 \item{default_formatting}{list. A named list of default column format configurations to apply when rendering the
-listing. Each name-value pair consists of a name corresponding to a data type (or "numeric" for all numeric
+listing. Each name-value pair consists of a name corresponding to a data class (or "numeric" for all numeric
 classes) and a value of type \code{fmt_config} with the format configuration that should be implemented for columns
-of that type. If named element "all" is included in the list, this configuration will be used for all data types
+of that class. If named element "all" is included in the list, this configuration will be used for all data classes
 not specified. Objects of type \code{fmt_config} can take 3 arguments: \code{format}, \code{na_str}, and \code{align}.}
 
 \item{col_formatting}{list. A named list of custom column formatting configuarations to apply to specific columns

--- a/man/listings.Rd
+++ b/man/listings.Rd
@@ -16,6 +16,8 @@ as_listing(
   key_cols = names(df)[1],
   disp_cols = NULL,
   non_disp_cols = NULL,
+  default_formatting = NULL,
+  col_formatting = NULL,
   main_title = NULL,
   subtitles = NULL,
   main_footer = NULL,

--- a/man/listings.Rd
+++ b/man/listings.Rd
@@ -64,10 +64,10 @@ columns. All other non-key columns are then treated as display columns. Invalid 
 \item{unique_rows}{logical(1). Should only unique rows be included in the listing. Defaults to \code{FALSE}.}
 
 \item{default_formatting}{list. A named list of default column format configurations to apply when rendering the
-listing. Each name-value pair consists of a name corresponding to a data class (or "numeric" for all numeric
-classes) and a value of type \code{fmt_config} with the format configuration that should be implemented for columns
-of that class. If named element "all" is included in the list, this configuration will be used for all data classes
-not specified. Objects of type \code{fmt_config} can take 3 arguments: \code{format}, \code{na_str}, and \code{align}.}
+listing. Each name-value pair consists of a name corresponding to a data class (or "numeric" for all unspecified
+numeric classes) and a value of type \code{fmt_config} with the format configuration that should be implemented for
+columns of that class. If named element "all" is included in the list, this configuration will be used for all
+data classes not specified. Objects of type \code{fmt_config} can take 3 arguments: \code{format}, \code{na_str}, and \code{align}.}
 
 \item{col_formatting}{list. A named list of custom column formatting configuarations to apply to specific columns
 when rendering the listing. Each name-value pair consists of a name corresponding to a column name and a value of

--- a/man/listings.Rd
+++ b/man/listings.Rd
@@ -61,6 +61,19 @@ the listing is rendered. Defaults to all columns of \code{df} not named in \code
 columns. All other non-key columns are then treated as display columns. Invalid if
 \code{disp_cols} is non-NULL.}
 
+\item{unique_rows}{logical(1). Should only unique rows be included in the listing. Defaults to \code{FALSE}.}
+
+\item{default_formatting}{list. A named list of default column format configurations to apply when rendering the
+listing. Each name-value pair consists of a name corresponding to a data type (or "numeric" for all numeric
+classes) and a value of type \code{fmt_config} with the format configuration that should be implemented for columns
+of that type. If named element "all" is included in the list, this configuration will be used for all data types
+not specified. Objects of type \code{fmt_config} can take 3 arguments: \code{format}, \code{na_str}, and \code{align}.}
+
+\item{col_formatting}{list. A named list of custom column formatting configuarations to apply to specific columns
+when rendering the listing. Each name-value pair consists of a name corresponding to a column name and a value of
+type \code{fmt_config} with the formatting configuration that should be implemented for that column. Objects of type
+\code{fmt_config} can take 3 arguments: \code{format}, \code{na_str}, and \code{align}. Defaults to \code{NULL}.}
+
 \item{main_title}{character(1) or NULL. The main title for the listing, or
 \code{NULL} (the default). Must be length 1 non-NULL.}
 

--- a/man/listings.Rd
+++ b/man/listings.Rd
@@ -16,7 +16,8 @@ as_listing(
   key_cols = names(df)[1],
   disp_cols = NULL,
   non_disp_cols = NULL,
-  default_formatting = NULL,
+  unique_rows = FALSE,
+  default_formatting = list(all = fmt_config()),
   col_formatting = NULL,
   main_title = NULL,
   subtitles = NULL,
@@ -36,7 +37,14 @@ add_listing_dispcol(df, new)
 
 listing_dispcols(df) <- value
 
-add_listing_col(df, name, fun = NULL, format = NULL, na_str = "-")
+add_listing_col(
+  df,
+  name,
+  fun = NULL,
+  format = NULL,
+  na_str = "-",
+  align = "center"
+)
 }
 \arguments{
 \item{df}{data.frame or listing_df. The (non-listing) data.frame to be converted to a listing or

--- a/tests/testthat/test-listings.R
+++ b/tests/testthat/test-listings.R
@@ -215,3 +215,35 @@ testthat::test_that("column inclusion and ordering stuff", {
     str <- toString(lsting3)
   })
 })
+
+testthat::test_that("unique_rows removes duplicate rows from listing", {
+  # only key_col
+  lsting <- as_listing(
+    ex_adsl,
+    key_cols = "SEX",
+    disp_cols = character(0),
+    unique_rows = TRUE
+  )
+  result_strings <- matrix_form(lsting)$strings
+  expected_strings <- matrix(
+    c("Sex", "F", "M", "U", "UNDIFFERENTIATED"),
+    dimnames = list(c(), "SEX")
+  )
+  expect_equal(expected_strings, result_strings)
+
+  # key_col and disp_col
+  lsting <- as_listing(
+    ex_adsl,
+    key_cols = "ARMCD",
+    disp_cols = "SEX",
+    unique_rows = TRUE
+  )
+  result_strings <- matrix_form(lsting)$strings
+  expected_strings <- matrix(
+    c("Planned Arm Code", "ARM A", "", "", "", "ARM B", "", "", "ARM C", "", "", "",
+      "Sex", "M", "F", "UNDIFFERENTIATED", "U", "F", "M", "U", "M", "F", "U", "UNDIFFERENTIATED"),
+    ncol = 2,
+    dimnames = list(c(), c("ARMCD", "SEX"))
+  )
+  expect_equal(expected_strings, result_strings)
+})

--- a/tests/testthat/test-paginate_listing.R
+++ b/tests/testthat/test-paginate_listing.R
@@ -18,14 +18,14 @@ testthat::test_that("pagination works vertically", {
   page1_expected <- paste0(
     "Unique Subject Identifier   Age   Continous Level Biomarker 1\n",
     "-------------------------------------------------------------\n",
-    "AB12345-BRA-1-id-134        47                6.5            \n",
-    "AB12345-BRA-1-id-141        35                7.5            \n"
+    "  AB12345-BRA-1-id-134      47                6.5            \n",
+    "  AB12345-BRA-1-id-141      35                7.5            \n"
   )
   page2_expected <- paste0(
     "Unique Subject Identifier   Age   Continous Level Biomarker 1\n",
     "-------------------------------------------------------------\n",
-    "AB12345-BRA-1-id-236        32                7.7            \n",
-    "AB12345-BRA-1-id-265        25               10.3            \n"
+    "  AB12345-BRA-1-id-236      32                7.7            \n",
+    "  AB12345-BRA-1-id-265      25               10.3            \n"
   )
   testthat::expect_equal(page1_result, page1_expected)
 
@@ -39,8 +39,8 @@ testthat::test_that("pagination works vertically", {
   page6_expected <- paste0(
     "Unique Subject Identifier   Age   Categorical Level Biomarker 2\n",
     "---------------------------------------------------------------\n",
-    "AB12345-BRA-1-id-42         36               MEDIUM            \n",
-    "AB12345-BRA-1-id-65         25               MEDIUM            \n"
+    "   AB12345-BRA-1-id-42      36               MEDIUM            \n",
+    "   AB12345-BRA-1-id-65      25               MEDIUM            \n"
   )
   testthat::expect_equal(
     toString(matrix_form(pages_listings2[[6]]), hsep = "-"),

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -17,7 +17,7 @@ testthat::test_that("Listing print correctly", {
     "AB12345-NGA-11-id-173   C: Combination        4.99722573047567      ",
     "AB12345-RUS-3-id-378    C: Combination        2.80323956920649      ",
     "AB12345-USA-1-id-261      B: Placebo          2.85516419937308      ",
-    "AB12345-USA-1-id-45       A: Drug X           0.463560441314472     "
+    " AB12345-USA-1-id-45      A: Drug X           0.463560441314472     "
   )
 
   testthat::expect_identical(res, exp)
@@ -68,10 +68,107 @@ testthat::test_that("Listing print correctly with different widths", {
     "id-261                        ",
     "AB12345   A: Drug    0.4635604",
     "-USA-1-      X       41314472 ",
-    "id-45                         "
+    " id-45                        "
   )
 
   testthat::expect_identical(res, res2)
   testthat::expect_identical(res, exp)
   testthat::expect_identical(res2, exp)
+})
+
+testthat::test_that("as_listing produces correct output when default_formatting is specified", {
+  anl$BMRKR1[3:6] <- NA
+  lsting <- as_listing(
+    anl,
+    key_cols = "USUBJID",
+    default_formatting = list(
+      all = fmt_config(align = "left"),
+      numeric = fmt_config(format = "xx.xx", na_str = "<No data>", align = "right"))
+    )
+
+  res <- strsplit(toString(matrix_form(lsting), hsep = "-"), "\\n")[[1]]
+  exp <- c(
+    "       Unique            Description                                ",
+    "       Subject                Of                                    ",
+    "     Identifier          Planned Arm     Continous Level Biomarker 1",
+    "--------------------------------------------------------------------",
+    "AB12345-CHN-1-id-307    B: Placebo                              4.57",
+    "AB12345-CHN-11-id-220   B: Placebo                         <No data>",
+    "AB12345-CHN-15-id-201   C: Combination                     <No data>",
+    "AB12345-CHN-15-id-262   C: Combination                          4.06",
+    "AB12345-CHN-3-id-128    A: Drug X                              14.42",
+    "AB12345-CHN-7-id-267    B: Placebo                         <No data>",
+    "AB12345-NGA-11-id-173   C: Combination                          5.00",
+    "AB12345-RUS-3-id-378    C: Combination                     <No data>",
+    "AB12345-USA-1-id-261    B: Placebo                              2.86",
+    "AB12345-USA-1-id-45     A: Drug X                               0.46"
+  )
+
+  testthat::expect_identical(res, exp)
+
+  testthat::expect_error(
+    {
+      as_listing(
+        anl,
+        key_cols = "USUBJID",
+        default_formatting = list(all = list(align = "left"))
+      )
+    },
+    "All format configurations supplied in `default_formatting` must be of type `fmt_config`."
+  )
+
+  testthat::expect_error(
+    {
+      as_listing(
+        anl,
+        key_cols = "USUBJID",
+        default_formatting = list(numeric = fmt_config(align = "left"))
+      )
+    },
+    paste("Format configurations must be supplied for all listing columns.",
+          "To cover all remaining columns please add an 'all' configuration to `default_formatting`.")
+  )
+})
+
+testthat::test_that("as_listing produces correct output when col_formatting is specified", {
+  anl$ARM[3:6] <- NA
+  lsting <- as_listing(
+    anl,
+    key_cols = "USUBJID",
+    col_formatting = list(
+      USUBJID = fmt_config(align = "right"),
+      ARM = fmt_config(format = sprintf_format("ARM #: %s"), na_str = "-", align = "left")
+    )
+  )
+
+  res <- strsplit(toString(matrix_form(lsting), hsep = "-"), "\\n")[[1]]
+  exp <- c(
+    "       Unique           Description                              ",
+    "       Subject              Of                                   ",
+    "     Identifier         Planned Arm   Continous Level Biomarker 1",
+    "-----------------------------------------------------------------",
+    " AB12345-CHN-1-id-307   ARM #: 2           4.57499101339464      ",
+    "AB12345-CHN-11-id-220   -                  10.2627340069523      ",
+    "AB12345-CHN-15-id-201   -                   6.9067988141075      ",
+    "AB12345-CHN-15-id-262   ARM #: 3           4.05546277230382      ",
+    " AB12345-CHN-3-id-128   ARM #: 1            14.424933692778      ",
+    " AB12345-CHN-7-id-267   -                   6.2067627167943      ",
+    "AB12345-NGA-11-id-173   ARM #: 3           4.99722573047567      ",
+    " AB12345-RUS-3-id-378   -                  2.80323956920649      ",
+    " AB12345-USA-1-id-261   ARM #: 2           2.85516419937308      ",
+    "  AB12345-USA-1-id-45   ARM #: 1           0.463560441314472     "
+  )
+
+  testthat::expect_identical(res, exp)
+
+  testthat::expect_error(
+    {
+      as_listing(
+        anl,
+        key_cols = "USUBJID",
+        col_formatting = list(all = list(align = "left"))
+      )
+    },
+    "All format configurations supplied in `col_formatting` must be of type `fmt_config`."
+  )
 })


### PR DESCRIPTION
Closes #87 

To consider:
- Default `fmt_config` settings (currently `format = NULL`, `na_str = "NA"`, `align = "center"`)
- Options to allow for `default_formatting` elements (currently `all`, `numeric`, and any data class)