### PR TITLE
Adds min package version

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -5,11 +5,6 @@ on:
   schedule:
     - cron: '45 3 * * 0'
   workflow_dispatch:
-  # Section to be removed before action is merged
-  push:
-    branches:
-      - verdepcheck_action
-  # end of section to be removed
 
 jobs:
   dependency-test:

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -6,7 +6,6 @@ on:
     - cron: '45 3 * * 0'
   workflow_dispatch:
   # Section to be removed before action is merged
-  #  note: branch below needs to point to main instead of new-verdepcheck-strategy
   push:
     branches:
       - verdepcheck_action
@@ -18,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         test-strategy: ["min_cohort", "min_isolated", "release", "max"]
-    uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@new-verdepcheck-strategy # Change back to "@main"
+    uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@main
     name: Dependency Test - ${{ matrix.test-strategy }} 🔢
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -5,14 +5,20 @@ on:
   schedule:
     - cron: '45 3 * * 0'
   workflow_dispatch:
+  # Section to be removed before action is merged
+  #  note: branch below needs to point to main instead of new-verdepcheck-strategy
+  push:
+    branches:
+      - verdepcheck_action
+  # end of section to be removed
 
 jobs:
   dependency-test:
     strategy:
       fail-fast: false
       matrix:
-        test-strategy: ["min", "release", "max"]
-    uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@main
+        test-strategy: ["min_cohort", "min_isolated", "release", "max"]
+    uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@new-verdepcheck-strategy # Change back to "@main"
     name: Dependency Test - ${{ matrix.test-strategy }} 🔢
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,9 +31,8 @@ Imports:
     utils
 Suggests:
     dplyr (>= 1.0.0),
-    knitr (>= 1.34),
+    knitr (>= 1.42),
     lifecycle  (>= 0.2.0),
-    rmarkdown (>= 2.19),
     testthat (>= 3.0.4)
 Config/Needs/verdepcheck:
     insightsengineering/formatters,
@@ -41,7 +40,6 @@ Config/Needs/verdepcheck:
     mllg/checkmate,
     tidyverse/dplyr,
     yihui/knitr,
-    rstudio/rmarkdown,
     r-lib/lifecycle,
     r-lib/testthat
 VignetteBuilder:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,22 +19,32 @@ Description: Listings are often part of the submission of clinical trial
 License: Apache License 2.0
 URL: https://github.com/insightsengineering/rlistings
 BugReports: https://github.com/insightsengineering/rlistings/issues
-Depends: 
+Depends:
     formatters (>= 0.5.2),
     methods,
-    tibble
+    tibble (>= 2.0.0)
 Imports:
-    checkmate,
+    checkmate (>= 2.1.0),
     grDevices,
     grid,
     stats,
     utils
-Suggests: 
-    dplyr,
+Suggests:
+    dplyr (>= 1.0.0),
     knitr (>= 1.34),
-    lifecycle,
-    testthat (>= 3.0)
-VignetteBuilder: 
+    lifecycle  (>= 0.2.0),
+    rmarkdown (>= 2.19),
+    testthat (>= 3.0.4)
+Config/Needs/verdepcheck:
+    insightsengineering/formatters,
+    tidyverse/tibble,
+    mllg/checkmate,
+    tidyverse/dplyr,
+    yihui/knitr,
+    rstudio/rmarkdown,
+    r-lib/lifecycle,
+    r-lib/testthat
+VignetteBuilder:
     knitr
 Config/Needs/website: insightsengineering/nesttemplate
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## rlistings 0.2.4.9000
  * Added `num_rep_cols` method for listings. Resolves error with key column repetition during pagination .
  * Fixed a bug when exporting a degenerative list, which is a data frame of a single row and a single column.
- * Specify minimal version of dependent packages.
+ * Specified minimal version of package dependencies.
 
 ## rlistings 0.2.3
  * Added new arguments `default_formatting` and `col_formatting` to `as_listing` to specify column format configurations.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## rlistings 0.2.4.9000
  * Added `num_rep_cols` method for listings. Resolves error with key column repetition during pagination .
  * Fixed a bug when exporting a degenerative list, which is a data frame of a single row and a single column.
+ * Specify minimal version of dependent packages.
  
 ## rlistings 0.2.3
  * Added new arguments `default_formatting` and `col_formatting` to `as_listing` to specify column format configurations.
@@ -9,7 +10,7 @@
  * Introduced `testthat` edition 3.
 
 ## rlistings 0.2.2
- * Moved `export_as_txt` to `formatters`. Added to reexports. 
+ * Moved `export_as_txt` to `formatters`. Added to reexports.
 
 ## rlistings 0.2.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,13 +2,12 @@
  * Added `num_rep_cols` method for listings. Resolves error with key column repetition during pagination .
  * Fixed a bug when exporting a degenerative list, which is a data frame of a single row and a single column.
  * Specify minimal version of dependent packages.
- 
+
 ## rlistings 0.2.3
  * Added new arguments `default_formatting` and `col_formatting` to `as_listing` to specify column format configurations.
  * Added new argument `unique_rows` to `as_listing` to remove duplicate rows from listing.
  * Default alignment is now `left` across all types. Reinstate `NA` as default.
  * Introduced `testthat` edition 3.
- * Specify minimal version of dependent packages.
 
 ## rlistings 0.2.2
  * Moved `export_as_txt` to `formatters`. Added to reexports.

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
  * Introduced `testthat` edition 3.
 
 ## rlistings 0.2.2
- * Moved `export_as_txt` to `formatters`. Added to reexports.
+ * Moved `export_as_txt` to `formatters`. Added to reexports. 
 
 ## rlistings 0.2.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
  * Added new argument `unique_rows` to `as_listing` to remove duplicate rows from listing.
  * Default alignment is now `left` across all types. Reinstate `NA` as default.
  * Introduced `testthat` edition 3.
+ * Specify minimal version of dependent packages.
 
 ## rlistings 0.2.2
  * Moved `export_as_txt` to `formatters`. Added to reexports.


### PR DESCRIPTION
WIP :: parent issue: https://github.com/insightsengineering/nestdevs-tasks/issues/7

Supersede:
* #130 

### 🔴 Checklist for PR Reviewer

- [ ] Tag yourself next to this repo on https://github.com/insightsengineering/nestdevs-tasks/issues/7
- [ ] Package versions are the same or higher than `main`
- [ ] Package list is the same
  - Only exception is `rmarkdown` (may have been removed on `Suggests`)
- [ ] All packages in `Imports`, `Depends` & `Suggests` are in new section `Config/Needs/verdepcheck`
- [ ] Added entry to `NEWS.md`
- [ ] Last `scheduled.yaml` action was run succesfully _(all 4 strategies)_
  - important: it's not the last commit, it's the one that runs 4 `Scheduled 🕰️ / Dependency` actions
- [ ] `scheduled.yaml` SHOULD NOT have any push on any branches

### 🔴 What's needed before merging?

This PR depends on some upstream changes that need to be finalized/merged before being ready to review.

#### Change in code

* [x] `formatters` release of the next version and update DESCRIPTION accordingly
  * `fmt_config` is required and only available at `formatters@main` atm
* `verdepcheck.yml` action (see comments)
  - [x] Remove `on: push` section 
  - [x] Change branch to main

#### PRS

- [x] verdepcheck
  * https://github.com/insightsengineering/verdepcheck/pull/24
  * https://github.com/insightsengineering/verdepcheck/pull/26
- [x] verdepcheck-action
  * https://github.com/insightsengineering/r-verdepcheck-action/pull/16

### Changes description

* Adds minimum version for packages `DESCRIPTION`
* Adds `Config/Need/verdepcheck` section in `DESCRIPTION`
* Updates verdepcheck action