### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Suggests:
     dplyr (>= 1.0.1),
     knitr (>= 1.42),
     lifecycle (>= 0.2.0),
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     stringi (>= 1.6),
     testthat (>= 3.1.5),
     withr (>= 2.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     stats,
     utils
 Suggests:
-    dplyr (>= 1.0.1),
+    dplyr (>= 1.0.2),
     knitr (>= 1.42),
     lifecycle (>= 0.2.0),
     rmarkdown (>= 2.23),

--- a/man/listing_methods.Rd
+++ b/man/listing_methods.Rd
@@ -60,7 +60,7 @@ used. Parameter is ignored if \code{tf_wrap = FALSE}.}
 
 \item{j}{(\code{any})\cr object passed to base \code{[} methods.}
 
-\item{drop}{For matrices and arrays.  If \code{TRUE} the result is
+\item{drop}{relevant for matrices and arrays.  If \code{TRUE} the result is
     coerced to the lowest possible dimension (see the examples).  This
     only works for extracting elements, not for the replacement.  See
     \code{\link[base]{drop}} for further details.


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.